### PR TITLE
[Feat/#4] 수강신청 API 구현

### DIFF
--- a/courseX-backend/src/main/java/com/acc/courseX/common/annotation/AuthUserId.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/common/annotation/AuthUserId.java
@@ -1,0 +1,12 @@
+package com.acc.courseX.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthUserId {}

--- a/courseX-backend/src/main/java/com/acc/courseX/common/code/AuthFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/common/code/AuthFailure.java
@@ -1,0 +1,17 @@
+package com.acc.courseX.common.code;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum AuthFailure implements FailureCode {
+  // 400
+  INVALID_AUTH_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 id입니다");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/common/config/WebConfig.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.acc.courseX.common.config;
+
+import java.util.List;
+
+import com.acc.courseX.common.resolver.AuthUserIdArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+  private final AuthUserIdArgumentResolver authUserIdArgumentResolver;
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authUserIdArgumentResolver);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/common/exception/AuthException.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/common/exception/AuthException.java
@@ -1,0 +1,9 @@
+package com.acc.courseX.common.exception;
+
+import com.acc.courseX.common.code.FailureCode;
+
+public class AuthException extends BaseException {
+  public AuthException(FailureCode failure) {
+    super(failure);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/common/resolver/AuthUserIdArgumentResolver.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/common/resolver/AuthUserIdArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.acc.courseX.common.resolver;
+
+import static com.acc.courseX.common.code.AuthFailure.INVALID_AUTH_ID;
+
+import com.acc.courseX.common.annotation.AuthUserId;
+import com.acc.courseX.common.exception.AuthException;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private static final String AUTH_HEADER_NAME = "X-USER-ID";
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    boolean hasAuthUserIdAnnotation = parameter.hasParameterAnnotation(AuthUserId.class);
+    boolean isUserIdLong = parameter.getParameterType().equals(Long.class);
+    return hasAuthUserIdAnnotation && isUserIdLong;
+  }
+
+  @Override
+  public Object resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    String header = webRequest.getHeader(AUTH_HEADER_NAME);
+    boolean hasNotAuthHeader = header == null;
+
+    if (hasNotAuthHeader) {
+      throw new AuthException(INVALID_AUTH_ID);
+    }
+
+    try {
+      return Long.parseLong(header);
+    } catch (NumberFormatException e) {
+      throw new AuthException(INVALID_AUTH_ID);
+    }
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseFailure.java
@@ -1,0 +1,22 @@
+package com.acc.courseX.course.code;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.acc.courseX.common.code.FailureCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum CourseFailure implements FailureCode {
+  // 400
+  COURSE_FULL(HttpStatus.BAD_REQUEST, "여석이 존재하지 않습니다"),
+
+  // 404
+  NOT_FOUND_COURSE(HttpStatus.NOT_FOUND, "해당하는 강의를 찾을 수 없습니다");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseSuccess.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseSuccess.java
@@ -12,7 +12,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum CourseSuccess implements SuccessCode {
   // 200
-  GET_COURSE_LIST(HttpStatus.OK, "강의 목록 조회에 성공했습니다.");
+  GET_COURSE_LIST(HttpStatus.OK, "강의 목록 조회에 성공했습니다."),
+
+  // 201
+  COURSE_ENROLLMENT_SUCCESS(HttpStatus.CREATED, "수강신청에 성공했습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseApi.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseApi.java
@@ -4,4 +4,6 @@ import org.springframework.http.ResponseEntity;
 
 public interface CourseApi {
   ResponseEntity<?> getCourses(String code);
+
+  ResponseEntity<?> enroll(Long courseId, Long userId);
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
@@ -1,5 +1,6 @@
 package com.acc.courseX.course.controller;
 
+import static com.acc.courseX.course.code.CourseSuccess.COURSE_ENROLLMENT_SUCCESS;
 import static com.acc.courseX.course.code.CourseSuccess.GET_COURSE_LIST;
 
 import java.util.List;
@@ -34,6 +35,7 @@ public class CourseController implements CourseApi {
   @PostMapping("/{courseId}/enroll")
   @Override
   public ResponseEntity<?> enroll(@PathVariable Long courseId, @AuthUserId Long userId) {
-    return null;
+    courseService.enroll(courseId, userId);
+    return ResponseUtil.success(COURSE_ENROLLMENT_SUCCESS);
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
@@ -11,6 +11,8 @@ import com.acc.courseX.course.service.CourseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +28,11 @@ public class CourseController implements CourseApi {
   public ResponseEntity<?> getCourses(@RequestParam(required = false) final String code) {
     List<CourseResponse> response = courseService.getCourses(code);
     return ResponseUtil.success(GET_COURSE_LIST, response);
+  }
+
+  @PostMapping("/{courseId}/enroll")
+  @Override
+  public ResponseEntity<?> enroll(@PathVariable Long courseId, Long userId) {
+    return null;
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
@@ -4,6 +4,7 @@ import static com.acc.courseX.course.code.CourseSuccess.GET_COURSE_LIST;
 
 import java.util.List;
 
+import com.acc.courseX.common.annotation.AuthUserId;
 import com.acc.courseX.common.response.ResponseUtil;
 import com.acc.courseX.course.dto.CourseResponse;
 import com.acc.courseX.course.service.CourseService;
@@ -32,7 +33,7 @@ public class CourseController implements CourseApi {
 
   @PostMapping("/{courseId}/enroll")
   @Override
-  public ResponseEntity<?> enroll(@PathVariable Long courseId, Long userId) {
+  public ResponseEntity<?> enroll(@PathVariable Long courseId, @AuthUserId Long userId) {
     return null;
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/entity/Course.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/entity/Course.java
@@ -1,5 +1,7 @@
 package com.acc.courseX.course.entity;
 
+import static com.acc.courseX.course.code.CourseFailure.COURSE_FULL;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +20,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
+import com.acc.courseX.course.exception.CourseException;
 import com.acc.courseX.user.entity.User;
 
 import lombok.AccessLevel;
@@ -64,5 +67,12 @@ public class Course {
 
   public String getCourseSchedule() {
     return schedules.stream().map(CourseSchedule::toString).collect(Collectors.joining(", "));
+  }
+
+  public void increaseCurrentStudents() {
+    if (this.currentStudents >= maxStudents) {
+      throw new CourseException(COURSE_FULL);
+    }
+    this.currentStudents++;
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/entity/CourseSchedule.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/entity/CourseSchedule.java
@@ -15,11 +15,13 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "course_schedules")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class CourseSchedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/courseX-backend/src/main/java/com/acc/courseX/course/exception/CourseException.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/exception/CourseException.java
@@ -1,0 +1,10 @@
+package com.acc.courseX.course.exception;
+
+import com.acc.courseX.common.code.FailureCode;
+import com.acc.courseX.common.exception.BaseException;
+
+public class CourseException extends BaseException {
+  public CourseException(FailureCode failure) {
+    super(failure);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/course/repository/CourseRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/repository/CourseRepository.java
@@ -1,11 +1,18 @@
 package com.acc.courseX.course.repository;
 
+import static com.acc.courseX.course.code.CourseFailure.NOT_FOUND_COURSE;
+
 import java.util.List;
 
 import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.course.exception.CourseException;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
   List<Course> findByCode(String code);
+
+  default Course findByIdOrThrow(Long courseId) {
+    return findById(courseId).orElseThrow(() -> new CourseException(NOT_FOUND_COURSE));
+  }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseService.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseService.java
@@ -6,4 +6,6 @@ import com.acc.courseX.course.dto.CourseResponse;
 
 public interface CourseService {
   List<CourseResponse> getCourses(String code);
+
+  void enroll(Long courseId, Long userId);
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
@@ -38,4 +38,7 @@ public class CourseServiceImpl implements CourseService {
                     course.getRemainingSeats()))
         .collect(Collectors.toList());
   }
+
+  @Override
+  public void enroll(Long courseId, Long userId) {}
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
@@ -6,6 +6,12 @@ import java.util.stream.Collectors;
 import com.acc.courseX.course.dto.CourseResponse;
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.repository.CourseRepository;
+import com.acc.courseX.enrollment.entity.Enrollment;
+import com.acc.courseX.enrollment.repository.EnrollmentRepository;
+import com.acc.courseX.enrollment.validator.EnrollmentValidator;
+import com.acc.courseX.enrollment.validator.EnrollmentValidatorFactory;
+import com.acc.courseX.user.entity.User;
+import com.acc.courseX.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CourseServiceImpl implements CourseService {
   private final CourseRepository courseRepository;
+  private final UserRepository userRepository;
+  private final EnrollmentValidatorFactory enrollmentValidatorFactory;
+  private final EnrollmentRepository enrollmentRepository;
 
   @Transactional(readOnly = true)
   @Override
@@ -40,5 +49,15 @@ public class CourseServiceImpl implements CourseService {
   }
 
   @Override
-  public void enroll(Long courseId, Long userId) {}
+  @Transactional
+  public void enroll(Long courseId, Long userId) {
+    User user = userRepository.findByIdOrThrow(userId);
+    Course course = courseRepository.findByIdOrThrow(courseId);
+    EnrollmentValidator validator = enrollmentValidatorFactory.getValidator(course);
+
+    validator.validate(course, user);
+    Enrollment newEnrollment = Enrollment.builder().course(course).user(user).build();
+    enrollmentRepository.save(newEnrollment);
+    course.increaseCurrentStudents();
+  }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
@@ -14,7 +14,6 @@ public enum EnrollmentFailure implements FailureCode {
   // 400
   MAJOR_MISMATCH(HttpStatus.BAD_REQUEST, "전공이 일치하는 전공수업이 아닙니다"),
   ALREADY_ENROLLED(HttpStatus.BAD_REQUEST, "이미 수강 신청이 완료된 강의입니다"),
-  COURSE_FULL(HttpStatus.BAD_REQUEST, "여석이 존재하지 않습니다"),
   TIMETABLE_CONFLICT(HttpStatus.BAD_REQUEST, "시간표가 중복되는 강의가 존재합니다");
 
   private final HttpStatus status;

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
@@ -1,0 +1,22 @@
+package com.acc.courseX.enrollment.code;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.acc.courseX.common.code.FailureCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum EnrollmentFailure implements FailureCode {
+  // 400
+  MAJOR_MISMATCH(HttpStatus.BAD_REQUEST, "전공이 일치하는 전공수업이 아닙니다"),
+  ALREADY_ENROLLED(HttpStatus.BAD_REQUEST, "이미 수강 신청이 완료된 강의입니다"),
+  COURSE_FULL(HttpStatus.BAD_REQUEST, "여석이 존재하지 않습니다"),
+  TIMETABLE_CONFLICT(HttpStatus.BAD_REQUEST, "시간표가 중복되는 강의가 존재합니다");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
@@ -16,6 +16,7 @@ import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.user.entity.User;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,4 +40,10 @@ public class Enrollment {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private EnrollmentStatus status = EnrollmentStatus.ENROLLED;
+
+  @Builder
+  private Enrollment(User user, Course course) {
+    this.user = user;
+    this.course = course;
+  }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
@@ -16,11 +16,13 @@ import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.user.entity.User;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "enrollments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Enrollment {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/exception/EnrollmentException.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/exception/EnrollmentException.java
@@ -1,0 +1,10 @@
+package com.acc.courseX.enrollment.exception;
+
+import com.acc.courseX.common.code.FailureCode;
+import com.acc.courseX.common.exception.BaseException;
+
+public class EnrollmentException extends BaseException {
+  public EnrollmentException(FailureCode failure) {
+    super(failure);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/repository/EnrollmentRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/repository/EnrollmentRepository.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.entity.Weekday;
 import com.acc.courseX.enrollment.entity.Enrollment;
+import com.acc.courseX.enrollment.entity.EnrollmentStatus;
 import com.acc.courseX.user.entity.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,11 +21,13 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
           + "JOIN Enrollment e ON cs1.course.id = e.course.id "
           + "JOIN User u ON e.user.id = u.id "
           + "WHERE u.id = :userId "
+          + "AND e.status = :enrollmentStatus "
           + "AND cs1.weekday = :weekday "
           + "AND cs1.startTime < :newEndTime "
           + "AND cs1.endTime > :newStartTime")
   boolean existsTimeOverlap(
       @Param("userId") Long userId,
+      @Param("enrollmentStatus") EnrollmentStatus status,
       @Param("weekday") Weekday weekday,
       @Param("newStartTime") LocalTime newStartTime,
       @Param("newEndTime") LocalTime newEndTime);

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/repository/EnrollmentRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,31 @@
+package com.acc.courseX.enrollment.repository;
+
+import java.time.LocalTime;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.course.entity.Weekday;
+import com.acc.courseX.enrollment.entity.Enrollment;
+import com.acc.courseX.user.entity.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+  boolean existsByCourseAndUser(Course course, User user);
+
+  @Query(
+      "SELECT COUNT(cs1) > 0 "
+          + "FROM CourseSchedule cs1 "
+          + "JOIN Enrollment e ON cs1.course.id = e.course.id "
+          + "JOIN User u ON e.user.id = u.id "
+          + "WHERE u.id = :userId "
+          + "AND cs1.weekday = :weekday "
+          + "AND cs1.startTime < :newEndTime "
+          + "AND cs1.endTime > :newStartTime")
+  boolean existsTimeOverlap(
+      @Param("userId") Long userId,
+      @Param("weekday") Weekday weekday,
+      @Param("newStartTime") LocalTime newStartTime,
+      @Param("newEndTime") LocalTime newEndTime);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
@@ -7,6 +7,7 @@ import static com.acc.courseX.enrollment.code.EnrollmentFailure.TIMETABLE_CONFLI
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.entity.CourseSchedule;
 import com.acc.courseX.course.exception.CourseException;
+import com.acc.courseX.enrollment.entity.EnrollmentStatus;
 import com.acc.courseX.enrollment.exception.EnrollmentException;
 import com.acc.courseX.enrollment.repository.EnrollmentRepository;
 import com.acc.courseX.user.entity.User;
@@ -43,6 +44,7 @@ public abstract class AbstractEnrollmentValidator implements EnrollmentValidator
       boolean isConflict =
           enrollmentRepository.existsTimeOverlap(
               user.getId(),
+              EnrollmentStatus.ENROLLED,
               newSchedule.getWeekday(),
               newSchedule.getStartTime(),
               newSchedule.getEndTime());

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
@@ -1,0 +1,56 @@
+package com.acc.courseX.enrollment.validator;
+
+import static com.acc.courseX.enrollment.code.EnrollmentFailure.ALREADY_ENROLLED;
+import static com.acc.courseX.enrollment.code.EnrollmentFailure.COURSE_FULL;
+import static com.acc.courseX.enrollment.code.EnrollmentFailure.TIMETABLE_CONFLICT;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.course.entity.CourseSchedule;
+import com.acc.courseX.enrollment.exception.EnrollmentException;
+import com.acc.courseX.enrollment.repository.EnrollmentRepository;
+import com.acc.courseX.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class AbstractEnrollmentValidator implements EnrollmentValidator {
+
+  private final EnrollmentRepository enrollmentRepository;
+
+  @Override
+  public void validate(Course course, User user) {
+    validateAlreadyEnrolled(course, user);
+    validateCourseSpecificRules(course, user);
+    validateRemainingSeats(course);
+    validateTimetableConflict(course, user);
+  }
+
+  protected void validateAlreadyEnrolled(Course course, User user) {
+    if (enrollmentRepository.existsByCourseAndUser(course, user)) {
+      throw new EnrollmentException(ALREADY_ENROLLED);
+    }
+  }
+
+  protected void validateRemainingSeats(Course course) {
+    if (course.getRemainingSeats() <= 0) {
+      throw new EnrollmentException(COURSE_FULL);
+    }
+  }
+
+  protected void validateTimetableConflict(Course course, User user) {
+    for (CourseSchedule newSchedule : course.getSchedules()) {
+      boolean isConflict =
+          enrollmentRepository.existsTimeOverlap(
+              user.getId(),
+              newSchedule.getWeekday(),
+              newSchedule.getStartTime(),
+              newSchedule.getEndTime());
+
+      if (isConflict) {
+        throw new EnrollmentException(TIMETABLE_CONFLICT);
+      }
+    }
+  }
+
+  protected abstract void validateCourseSpecificRules(Course course, User user);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/AbstractEnrollmentValidator.java
@@ -1,11 +1,12 @@
 package com.acc.courseX.enrollment.validator;
 
+import static com.acc.courseX.course.code.CourseFailure.COURSE_FULL;
 import static com.acc.courseX.enrollment.code.EnrollmentFailure.ALREADY_ENROLLED;
-import static com.acc.courseX.enrollment.code.EnrollmentFailure.COURSE_FULL;
 import static com.acc.courseX.enrollment.code.EnrollmentFailure.TIMETABLE_CONFLICT;
 
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.entity.CourseSchedule;
+import com.acc.courseX.course.exception.CourseException;
 import com.acc.courseX.enrollment.exception.EnrollmentException;
 import com.acc.courseX.enrollment.repository.EnrollmentRepository;
 import com.acc.courseX.user.entity.User;
@@ -33,7 +34,7 @@ public abstract class AbstractEnrollmentValidator implements EnrollmentValidator
 
   protected void validateRemainingSeats(Course course) {
     if (course.getRemainingSeats() <= 0) {
-      throw new EnrollmentException(COURSE_FULL);
+      throw new CourseException(COURSE_FULL);
     }
   }
 

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/EnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/EnrollmentValidator.java
@@ -1,0 +1,8 @@
+package com.acc.courseX.enrollment.validator;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.user.entity.User;
+
+public interface EnrollmentValidator {
+  void validate(Course course, User user);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/EnrollmentValidatorFactory.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/EnrollmentValidatorFactory.java
@@ -1,0 +1,24 @@
+package com.acc.courseX.enrollment.validator;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.course.entity.CourseType;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnrollmentValidatorFactory {
+
+  private final MajorCourseEnrollmentValidator majorValidator;
+  private final GeneralCourseEnrollmentValidator generalValidator;
+
+  public EnrollmentValidatorFactory(
+      MajorCourseEnrollmentValidator majorValidator,
+      GeneralCourseEnrollmentValidator generalValidator) {
+    this.majorValidator = majorValidator;
+    this.generalValidator = generalValidator;
+  }
+
+  public EnrollmentValidator getValidator(Course course) {
+    return course.getCourseType() == CourseType.MAJOR ? majorValidator : generalValidator;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/GeneralCourseEnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/GeneralCourseEnrollmentValidator.java
@@ -1,0 +1,18 @@
+package com.acc.courseX.enrollment.validator;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.enrollment.repository.EnrollmentRepository;
+import com.acc.courseX.user.entity.User;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GeneralCourseEnrollmentValidator extends AbstractEnrollmentValidator {
+
+  public GeneralCourseEnrollmentValidator(EnrollmentRepository enrollmentRepository) {
+    super(enrollmentRepository);
+  }
+
+  @Override
+  protected void validateCourseSpecificRules(Course course, User user) {}
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/MajorCourseEnrollmentValidator.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/validator/MajorCourseEnrollmentValidator.java
@@ -1,0 +1,27 @@
+package com.acc.courseX.enrollment.validator;
+
+import static com.acc.courseX.enrollment.code.EnrollmentFailure.MAJOR_MISMATCH;
+
+import com.acc.courseX.course.entity.Course;
+import com.acc.courseX.enrollment.exception.EnrollmentException;
+import com.acc.courseX.enrollment.repository.EnrollmentRepository;
+import com.acc.courseX.user.entity.User;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MajorCourseEnrollmentValidator extends AbstractEnrollmentValidator {
+
+  public MajorCourseEnrollmentValidator(EnrollmentRepository enrollmentRepository) {
+    super(enrollmentRepository);
+  }
+
+  @Override
+  protected void validateCourseSpecificRules(Course course, User user) {
+    boolean isMajorMismatch = !course.getProfessor().getMajor().equals(user.getMajor());
+
+    if (isMajorMismatch) {
+      throw new EnrollmentException(MAJOR_MISMATCH);
+    }
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/user/code/UserFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/user/code/UserFailure.java
@@ -1,0 +1,19 @@
+package com.acc.courseX.user.code;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.acc.courseX.common.code.FailureCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum UserFailure implements FailureCode {
+  // 404
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당하는 유저를 찾을 수 없습니다");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/user/entity/User.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/user/entity/User.java
@@ -1,5 +1,8 @@
 package com.acc.courseX.user.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,9 +13,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.acc.courseX.common.entity.BaseTime;
+import com.acc.courseX.enrollment.entity.Enrollment;
 import com.acc.courseX.major.entity.Major;
 
 import lombok.AccessLevel;
@@ -44,4 +49,7 @@ public class User extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "major_id", nullable = false)
   private Major major;
+
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+  private List<Enrollment> enrollments = new ArrayList<>();
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/user/entity/User.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/user/entity/User.java
@@ -1,8 +1,5 @@
 package com.acc.courseX.user.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,11 +10,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.acc.courseX.common.entity.BaseTime;
-import com.acc.courseX.enrollment.entity.Enrollment;
 import com.acc.courseX.major.entity.Major;
 
 import lombok.AccessLevel;
@@ -49,7 +44,4 @@ public class User extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "major_id", nullable = false)
   private Major major;
-
-  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-  private List<Enrollment> enrollments = new ArrayList<>();
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/user/exception/UserException.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.acc.courseX.user.exception;
+
+import com.acc.courseX.common.code.FailureCode;
+import com.acc.courseX.common.exception.BaseException;
+
+public class UserException extends BaseException {
+  public UserException(FailureCode failure) {
+    super(failure);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/user/repository/UserRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.acc.courseX.user.repository;
+
+import static com.acc.courseX.user.code.UserFailure.NOT_FOUND_USER;
+
+import com.acc.courseX.user.entity.User;
+import com.acc.courseX.user.exception.UserException;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+  default User findByIdOrThrow(Long userId) {
+    return findById(userId).orElseThrow(() -> new UserException(NOT_FOUND_USER));
+  }
+}

--- a/courseX-backend/src/main/resources/jpa.yaml
+++ b/courseX-backend/src/main/resources/jpa.yaml
@@ -1,13 +1,23 @@
-spring.config.activate.on-profile: dev
 spring:
+  jpa:
+    properties:
+      hibernate:
+        dialect: ${JPA_DATABASE_DIALECT}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
   jpa:
     hibernate:
       ddl-auto: none
-    database-platform: ${JPA_DATABASE_PLATFORM}
-    database: ${JPA_DATABASE}
+
 ---
-spring.config.activate.on-profile: local
 spring:
+  config:
+    activate:
+      on-profile: local
   jpa:
     hibernate:
       ddl-auto: update
@@ -15,12 +25,12 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-      database-platform: ${JPA_DATABASE_PLATFORM}
-      database: ${JPA_DATABASE}
 
 ---
-spring.config.activate.on-profile: test
 spring:
+  config:
+    activate:
+      on-profile: test
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -28,5 +38,3 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-      database-platform: ${JPA_DATABASE_PLATFORM}
-      database: ${JPA_DATABASE}


### PR DESCRIPTION
# 📄 Work Description
<!-- 작업에 대한 설명을 작성해주세요 -->
- 수강신청 API를 구현했습니다
- 엔티티 설계 당시 저희가 생각했던 비즈니스 로직은 다음과 같습니다
  1. 이미 신청한 수업에 대해서는 수강신청에 할 수 없다
  2. 다른 수업과 수업 시간이 겹칠 경우 수강신청 할 수 없다
  3. 해당 수업의 여석이 존재하지 않을 경우 수강신청 할 수 없다 
  4. 전공 수업의 경우 수업을 진행하는 교수와 전공이 같아야 한다
- 교양 수업과 전공 수업의 수강 신청을 판단하는 기준에 4번만 차이가 있어 템플릿 메서드 패턴과 팩토리 클래스를 통해 수강 신청 로직을 검증하는 클래스들을 구현했습니다
  - enrollment 패키지 하위 validator 패키지를 참고하시면 됩니다
- 수강 신청 시 어떤 학생이 수강 신청하는지 구분하기 위해 인증 로직을 간단히 구현한 @AuthUserId 라는 커스텀 어노테이션을 구현했습니다
  - header에서 X-User-Id를 추출하여 Long 타입으로 변환하는 역할을 수행합니다
  - 본 프로젝트는 부하테스트 및 모니터링 학습 목적의 프로젝트이므로 스프링 시큐리티나 JWT 등의 구체적인 인증 로직까지 구현하는 것은 불필요하다고 판단하여 커스텀어노테이션을 구현해보았습니다  

# ⚙️ ISSUE
- closed #4


# 📷 Screenshot
<!-- ex) 스웨거, 포스트맨 등의 기록을 첨부해주세요 -->


# 💬 To Reviewers
<!-- 리뷰어에게 하고싶은 말 -->
- 개인적으로 학생별로 수강 가능 학점에 대한 컬럼도 추가해야할 것 같은데 어떻게 생각하시나요? 그리고 수강신청 시에 이 수강가능 학점을 초과하지는 않는지 검증하는 로직도 추가로 필요하다는 생각이 듭니다