### PR TITLE
[Feat/#7] 사용자 로그 조회 API 구현

### DIFF
--- a/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseSuccess.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/code/CourseSuccess.java
@@ -15,7 +15,9 @@ public enum CourseSuccess implements SuccessCode {
   GET_COURSE_LIST(HttpStatus.OK, "강의 목록 조회에 성공했습니다."),
 
   // 201
-  COURSE_ENROLLMENT_SUCCESS(HttpStatus.CREATED, "수강신청에 성공했습니다");
+  COURSE_ENROLLMENT_SUCCESS(HttpStatus.CREATED, "수강신청에 성공했습니다"),
+
+  COURSE_ENROLLMENT_CANCEL_SUCCESS(HttpStatus.OK, "수강 취소가 완료되었습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseApi.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseApi.java
@@ -6,4 +6,6 @@ public interface CourseApi {
   ResponseEntity<?> getCourses(String code);
 
   ResponseEntity<?> enroll(Long courseId, Long userId);
+
+  ResponseEntity<?> cancelEnrollment(Long enrollmentId, Long userId);
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/controller/CourseController.java
@@ -1,5 +1,6 @@
 package com.acc.courseX.course.controller;
 
+import static com.acc.courseX.course.code.CourseSuccess.COURSE_ENROLLMENT_CANCEL_SUCCESS;
 import static com.acc.courseX.course.code.CourseSuccess.COURSE_ENROLLMENT_SUCCESS;
 import static com.acc.courseX.course.code.CourseSuccess.GET_COURSE_LIST;
 
@@ -12,6 +13,7 @@ import com.acc.courseX.course.service.CourseService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,5 +39,12 @@ public class CourseController implements CourseApi {
   public ResponseEntity<?> enroll(@PathVariable Long courseId, @AuthUserId Long userId) {
     courseService.enroll(courseId, userId);
     return ResponseUtil.success(COURSE_ENROLLMENT_SUCCESS);
+  }
+
+  @DeleteMapping("/enrollments/{enrollmentId}")
+  public ResponseEntity<?> cancelEnrollment(
+      @PathVariable Long enrollmentId, @AuthUserId Long userId) {
+    courseService.cancelEnrollment(enrollmentId, userId);
+    return ResponseUtil.success(COURSE_ENROLLMENT_CANCEL_SUCCESS);
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/entity/Course.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/entity/Course.java
@@ -75,4 +75,10 @@ public class Course {
     }
     this.currentStudents++;
   }
+
+  public void decreaseCurrentStudents() {
+    if (this.currentStudents > 0) {
+      this.currentStudents--;
+    }
+  }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseService.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseService.java
@@ -8,4 +8,6 @@ public interface CourseService {
   List<CourseResponse> getCourses(String code);
 
   void enroll(Long courseId, Long userId);
+
+  void cancelEnrollment(Long enrollmentId, Long userId);
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/course/service/CourseServiceImpl.java
@@ -1,5 +1,7 @@
 package com.acc.courseX.course.service;
 
+import static com.acc.courseX.enrollment.code.EnrollmentFailure.*;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -7,6 +9,8 @@ import com.acc.courseX.course.dto.CourseResponse;
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.repository.CourseRepository;
 import com.acc.courseX.enrollment.entity.Enrollment;
+import com.acc.courseX.enrollment.entity.EnrollmentStatus;
+import com.acc.courseX.enrollment.exception.EnrollmentException;
 import com.acc.courseX.enrollment.repository.EnrollmentRepository;
 import com.acc.courseX.enrollment.validator.EnrollmentValidator;
 import com.acc.courseX.enrollment.validator.EnrollmentValidatorFactory;
@@ -59,5 +63,27 @@ public class CourseServiceImpl implements CourseService {
     Enrollment newEnrollment = Enrollment.builder().course(course).user(user).build();
     enrollmentRepository.save(newEnrollment);
     course.increaseCurrentStudents();
+  }
+
+  @Override
+  @Transactional
+  public void cancelEnrollment(Long enrollmentId, Long userId) {
+    Enrollment enrollment =
+        enrollmentRepository
+            .findById(enrollmentId)
+            .orElseThrow(() -> new EnrollmentException(ENROLLMENT_NOT_FOUND));
+
+    if (!enrollment.getUser().getId().equals(userId)) {
+      throw new EnrollmentException(UNAUTHORIZED_CANCEL);
+    }
+
+    if (enrollment.getStatus() == EnrollmentStatus.CANCELLED) {
+      throw new EnrollmentException(ENROLLMENT_ALREADY_CANCELLED);
+    }
+
+    enrollment.cancel();
+
+    Course course = enrollment.getCourse();
+    course.decreaseCurrentStudents();
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/code/EnrollmentFailure.java
@@ -14,8 +14,11 @@ public enum EnrollmentFailure implements FailureCode {
   // 400
   MAJOR_MISMATCH(HttpStatus.BAD_REQUEST, "전공이 일치하는 전공수업이 아닙니다"),
   ALREADY_ENROLLED(HttpStatus.BAD_REQUEST, "이미 수강 신청이 완료된 강의입니다"),
-  TIMETABLE_CONFLICT(HttpStatus.BAD_REQUEST, "시간표가 중복되는 강의가 존재합니다");
+  TIMETABLE_CONFLICT(HttpStatus.BAD_REQUEST, "시간표가 중복되는 강의가 존재합니다"),
 
+  ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강 신청입니다."),
+  UNAUTHORIZED_CANCEL(HttpStatus.FORBIDDEN, "본인의 수강 신청만 취소할 수 있습니다."),
+  ENROLLMENT_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강 신청입니다.");
   private final HttpStatus status;
   private final String message;
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/enrollment/entity/Enrollment.java
@@ -46,4 +46,8 @@ public class Enrollment {
     this.user = user;
     this.course = course;
   }
+
+  public void cancel() {
+    this.status = EnrollmentStatus.CANCELLED;
+  }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
@@ -1,0 +1,169 @@
+package com.acc.courseX.log.aspect;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.service.LogService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LogAspect {
+  private final LogService logService;
+  private final ObjectMapper objectMapper;
+
+  @AfterReturning("execution(* com.acc.courseX.course.controller.CourseController.getCourses(..))")
+  public void logAfterViewCourse(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      String code = (String) args[0];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+      Long userId = extractUserIdFromRequest(request);
+      if (userId == null) return;
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseCode", code);
+
+      logService.createLog(
+          userId,
+          "view_course",
+          "courses",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log view course action", e);
+    }
+  }
+
+  @AfterReturning("execution(* com.acc.courseX.course.controller.CourseController.enroll(..))")
+  public void logAfterEnrollment(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long courseId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseId", courseId);
+
+      logService.createLog(
+          userId,
+          "enroll_course",
+          "enrollments",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log enrollment action", e);
+    }
+  }
+
+  @AfterThrowing(
+      pointcut = "execution(* com.acc.courseX.course.controller.CourseController.enroll(..))",
+      throwing = "exception")
+  public void logAfterEnrollmentFailure(JoinPoint joinPoint, Exception exception) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long courseId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseId", courseId);
+      metadata.put("errorMessage", exception.getMessage());
+      metadata.put("exceptionType", exception.getClass().getSimpleName());
+
+      logService.createLog(
+          userId,
+          "enroll_course_failure",
+          "enrollments",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log enrollment failure action", e);
+    }
+  }
+
+  @AfterReturning(
+      "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))")
+  public void logAfterCancelEnrollment(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long enrollmentId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("enrollmentId", enrollmentId);
+
+      logService.createLog(
+          userId,
+          "drop_course",
+          "enrollments",
+          enrollmentId,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log cancel enrollment action", e);
+    }
+  }
+
+  @AfterThrowing(
+      pointcut =
+          "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))",
+      throwing = "exception")
+  public void logAfterCancelEnrollmentFailure(JoinPoint joinPoint, Exception exception) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long enrollmentId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("enrollmentId", enrollmentId);
+      metadata.put("errorMessage", exception.getMessage());
+      metadata.put("exceptionType", exception.getClass().getSimpleName());
+
+      logService.createLog(
+          userId,
+          "drop_course_failure",
+          "enrollments",
+          enrollmentId,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log cancel enrollment failure action", e);
+    }
+  }
+
+  private Long extractUserIdFromRequest(HttpServletRequest request) {
+    String userId = request.getHeader("X-User-Id");
+    return userId != null ? Long.parseLong(userId) : null;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/code/LogSuccess.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/code/LogSuccess.java
@@ -1,0 +1,27 @@
+package com.acc.courseX.log.code;
+
+import com.acc.courseX.common.code.SuccessCode;
+
+import org.springframework.http.HttpStatus;
+
+public enum LogSuccess implements SuccessCode {
+  GET_LOG_LIST(HttpStatus.OK, "로그 조회에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  LogSuccess(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return httpStatus;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
@@ -1,0 +1,46 @@
+package com.acc.courseX.log.controller;
+
+import static com.acc.courseX.log.code.LogSuccess.GET_LOG_LIST;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import com.acc.courseX.common.response.ResponseUtil;
+import com.acc.courseX.log.dto.LogResponse;
+import com.acc.courseX.log.service.LogService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/logs")
+@RequiredArgsConstructor
+public class LogController {
+  private final LogService logService;
+
+  @GetMapping
+  public ResponseEntity<?> getLogs(
+      @RequestParam(required = false) Long userId,
+      @RequestParam(required = false) String actionType,
+      @RequestParam(required = false) String targetTable,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate) {
+
+    LocalDateTime startDateTime =
+        startDate != null ? LocalDateTime.of(startDate, LocalTime.MIN) : null;
+    LocalDateTime endDateTime = endDate != null ? LocalDateTime.of(endDate, LocalTime.MAX) : null;
+
+    List<LogResponse> response =
+        logService.getLogs(userId, actionType, targetTable, startDateTime, endDateTime);
+    return ResponseUtil.success(GET_LOG_LIST, response);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/dto/LogResponse.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/dto/LogResponse.java
@@ -1,0 +1,41 @@
+package com.acc.courseX.log.dto;
+
+import java.time.LocalDateTime;
+
+import com.acc.courseX.log.entity.Log;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LogResponse {
+  private Long id;
+  private Long userId;
+  private String userName;
+  private String actionType;
+  private String targetTable;
+  private Long targetId;
+  private String metadata;
+  private String ipAddress;
+  private String userAgent;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime createdAt;
+
+  public static LogResponse from(Log log) {
+    return LogResponse.builder()
+        .id(log.getId())
+        .userId(log.getUser() != null ? log.getUser().getId() : null)
+        .userName(log.getUser() != null ? log.getUser().getName() : null)
+        .actionType(log.getActionType())
+        .targetTable(log.getTargetTable())
+        .targetId(log.getTargetId())
+        .metadata(log.getMetadata())
+        .ipAddress(log.getIpAddress())
+        .userAgent(log.getUserAgent())
+        .createdAt(log.getCreatedAt())
+        .build();
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/entity/Log.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/entity/Log.java
@@ -1,0 +1,79 @@
+package com.acc.courseX.log.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import com.acc.courseX.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "logs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Log {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(nullable = false)
+  private String actionType;
+
+  @Column(nullable = false)
+  private String targetTable;
+
+  private Long targetId;
+
+  @Column(columnDefinition = "JSON")
+  private String metadata;
+
+  private String ipAddress;
+
+  private String userAgent;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public Log(
+      User user,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      String ipAddress,
+      String userAgent) {
+    this.user = user;
+    this.actionType = actionType;
+    this.targetTable = targetTable;
+    this.targetId = targetId;
+    this.metadata = metadata;
+    this.ipAddress = ipAddress;
+    this.userAgent = userAgent;
+    this.createdAt = LocalDateTime.now(); // 이 부분에서 현재 시간으로 초기화
+  }
+
+  @PrePersist
+  public void prePersist() {
+    if (this.createdAt == null) {
+      this.createdAt = LocalDateTime.now();
+    }
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/repository/LogRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/repository/LogRepository.java
@@ -1,0 +1,36 @@
+package com.acc.courseX.log.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.acc.courseX.log.entity.Log;
+import com.acc.courseX.user.entity.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LogRepository extends JpaRepository<Log, Long> {
+  List<Log> findByUser(User user);
+
+  List<Log> findByActionType(String actionType);
+
+  List<Log> findByTargetTable(String targetTable);
+
+  List<Log> findByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+  @Query(
+      "SELECT l FROM Log l WHERE "
+          + "(:userId IS NULL OR l.user.id = :userId) AND "
+          + "(:actionType IS NULL OR l.actionType = :actionType) AND "
+          + "(:targetTable IS NULL OR l.targetTable = :targetTable) AND "
+          + "(:startDate IS NULL OR l.createdAt >= :startDate) AND "
+          + "(:endDate IS NULL OR l.createdAt <= :endDate) "
+          + "ORDER BY l.createdAt DESC")
+  List<Log> findWithFilters(
+      @Param("userId") Long userId,
+      @Param("actionType") String actionType,
+      @Param("targetTable") String targetTable,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogService.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogService.java
@@ -1,0 +1,25 @@
+package com.acc.courseX.log.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.dto.LogResponse;
+
+public interface LogService {
+  void createLog(
+      Long userId,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      HttpServletRequest request);
+
+  List<LogResponse> getLogs(
+      Long userId,
+      String actionType,
+      String targetTable,
+      LocalDateTime startDate,
+      LocalDateTime endDate);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
@@ -1,0 +1,82 @@
+package com.acc.courseX.log.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.dto.LogResponse;
+import com.acc.courseX.log.entity.Log;
+import com.acc.courseX.log.repository.LogRepository;
+import com.acc.courseX.user.entity.User;
+import com.acc.courseX.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LogServiceImpl implements LogService {
+  private final LogRepository logRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public void createLog(
+      Long userId,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      HttpServletRequest request) {
+    User user = null;
+    if (userId != null) {
+      user = userRepository.findById(userId).orElse(null);
+    }
+
+    String ipAddress = getClientIp(request);
+    String userAgent = request.getHeader("User-Agent");
+
+    Log log =
+        Log.builder()
+            .user(user)
+            .actionType(actionType)
+            .targetTable(targetTable)
+            .targetId(targetId)
+            .metadata(metadata)
+            .ipAddress(ipAddress)
+            .userAgent(userAgent)
+            .build();
+
+    logRepository.save(log);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<LogResponse> getLogs(
+      Long userId,
+      String actionType,
+      String targetTable,
+      LocalDateTime startDate,
+      LocalDateTime endDate) {
+    List<Log> logs =
+        logRepository.findWithFilters(userId, actionType, targetTable, startDate, endDate);
+    return logs.stream().map(LogResponse::from).collect(Collectors.toList());
+  }
+
+  private String getClientIp(HttpServletRequest request) {
+    String ipAddress = request.getHeader("X-Forwarded-For");
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getRemoteAddr();
+    }
+    return ipAddress;
+  }
+}


### PR DESCRIPTION
# 📄 Work Description
- 사용자 로그 조회 API를 구현했습니다.
- 조회 가능한 요소는 다음과 같습니다.
  - 사용자 ID별 필터링: `userId=1`
  - 액션 타입별 필터링: `actionType=enroll_course`, `drop_course`, `view_course`, `view_enrollment`
  - 날짜 범위 필터링: `startDate=2025-04-01&endDate=2025-04-30`
  - 타겟 테이블별 필터링: `targetTable=courses`, `enrollments`


# ⚙️ ISSUE
- closed #7 


# 📷 Screenshot
![image](https://github.com/user-attachments/assets/8f13264f-026b-4272-a108-aebe1146bb00)



# 💬 To Reviewers
로그 조회 요소로 추가할 것이 있다면 말씀해주세요.


# 🔗 Reference
