### PR TITLE
[Feat/#7] 사용자 로그 조회 API 구현

### DIFF
--- a/courseX-backend/build.gradle.kts
+++ b/courseX-backend/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.springframework.boot:spring-boot-starter-aop")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/courseX-backend/src/main/java/com/acc/courseX/config/AsyncConfig.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.acc.courseX.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean(name = "logTaskExecutor")
+  public ThreadPoolTaskExecutor logTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(5);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("LogAsync-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
@@ -16,8 +16,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -92,6 +94,20 @@ public class LogAspect {
 
     Map<String, Object> metadata = errorMetadata(exception);
     logAction(userId, LogAction.DROP_COURSE_FAILURE, "enrollments", enrollmentId, metadata);
+  }
+
+  @Around("execution(* com.acc.courseX.log.service.LogService.*(..))")
+  public Object measureLogServiceExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    long startTime = System.currentTimeMillis();
+    Object result = joinPoint.proceed(); // 메서드 실행
+    long executionTime = System.currentTimeMillis() - startTime;
+
+    log.info(
+        "LogService method [{}] executed in {} ms",
+        joinPoint.getSignature().toShortString(),
+        executionTime);
+
+    return result;
   }
 
   private void logAction(

--- a/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import com.acc.courseX.course.entity.Course;
 import com.acc.courseX.course.repository.CourseRepository;
-import com.acc.courseX.enrollment.entity.Enrollment;
 import com.acc.courseX.enrollment.repository.EnrollmentRepository;
 import com.acc.courseX.log.entity.LogAction;
 import com.acc.courseX.log.service.LogService;
@@ -75,11 +74,7 @@ public class LogAspect {
     Long enrollmentId = (Long) joinPoint.getArgs()[0];
     Long userId = (Long) joinPoint.getArgs()[1];
 
-    Enrollment enrollment = enrollmentRepository.findById(enrollmentId).orElse(null);
     Map<String, Object> metadata = new HashMap<>();
-    if (enrollment != null) {
-      metadata.put("courseId", enrollment.getCourse().getId());
-    }
 
     logAction(userId, LogAction.DROP_COURSE, "enrollments", enrollmentId, metadata);
   }

--- a/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
@@ -107,7 +107,7 @@ public class LogAspect {
   }
 
   @AfterReturning(
-      "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))")
+      "execution(* com.acc.courseX.enrollment.controller.EnrollmentController.cancel(..))")
   public void logAfterCancelEnrollment(JoinPoint joinPoint) {
     try {
       Object[] args = joinPoint.getArgs();
@@ -134,7 +134,7 @@ public class LogAspect {
 
   @AfterThrowing(
       pointcut =
-          "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))",
+          "execution(* com.acc.courseX.enrollment.controller.EnrollmentController.cancel(..))",
       throwing = "exception")
   public void logAfterCancelEnrollmentFailure(JoinPoint joinPoint, Exception exception) {
     try {

--- a/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/aspect/LogAspect.java
@@ -1,0 +1,169 @@
+package com.acc.courseX.log.aspect;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.service.LogService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LogAspect {
+  private final LogService logService;
+  private final ObjectMapper objectMapper;
+
+  @AfterReturning("execution(* com.acc.courseX.course.controller.CourseController.getCourses(..))")
+  public void logAfterViewCourse(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      String code = (String) args[0];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+      Long userId = extractUserIdFromRequest(request);
+      if (userId == null) return;
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseCode", code);
+
+      logService.createLog(
+          userId,
+          "view_course",
+          "courses",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log view course action", e);
+    }
+  }
+
+  @AfterReturning("execution(* com.acc.courseX.course.controller.CourseController.enroll(..))")
+  public void logAfterEnrollment(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long courseId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseId", courseId);
+
+      logService.createLog(
+          userId,
+          "enroll_course",
+          "enrollments",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log enrollment action", e);
+    }
+  }
+
+  @AfterThrowing(
+      pointcut = "execution(* com.acc.courseX.course.controller.CourseController.enroll(..))",
+      throwing = "exception")
+  public void logAfterEnrollmentFailure(JoinPoint joinPoint, Exception exception) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long courseId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("courseId", courseId);
+      metadata.put("errorMessage", exception.getMessage());
+      metadata.put("exceptionType", exception.getClass().getSimpleName());
+
+      logService.createLog(
+          userId,
+          "enroll_course_failure",
+          "enrollments",
+          null,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log enrollment failure action", e);
+    }
+  }
+
+  @AfterReturning(
+      "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))")
+  public void logAfterCancelEnrollment(JoinPoint joinPoint) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long enrollmentId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("enrollmentId", enrollmentId);
+
+      logService.createLog(
+          userId,
+          "drop_course",
+          "enrollments",
+          enrollmentId,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log cancel enrollment action", e);
+    }
+  }
+
+  @AfterThrowing(
+      pointcut =
+          "execution(* com.acc.courseX.course.controller.CourseController.cancelEnrollment(..))",
+      throwing = "exception")
+  public void logAfterCancelEnrollmentFailure(JoinPoint joinPoint, Exception exception) {
+    try {
+      Object[] args = joinPoint.getArgs();
+      Long enrollmentId = (Long) args[0];
+      Long userId = (Long) args[1];
+
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      Map<String, Object> metadata = new HashMap<>();
+      metadata.put("enrollmentId", enrollmentId);
+      metadata.put("errorMessage", exception.getMessage());
+      metadata.put("exceptionType", exception.getClass().getSimpleName());
+
+      logService.createLog(
+          userId,
+          "drop_course_failure",
+          "enrollments",
+          enrollmentId,
+          objectMapper.writeValueAsString(metadata),
+          request);
+    } catch (Exception e) {
+      log.error("Failed to log cancel enrollment failure action", e);
+    }
+  }
+
+  private Long extractUserIdFromRequest(HttpServletRequest request) {
+    String userId = request.getHeader("X-User-Id");
+    return userId != null ? Long.parseLong(userId) : null;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/code/LogSuccess.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/code/LogSuccess.java
@@ -1,0 +1,27 @@
+package com.acc.courseX.log.code;
+
+import com.acc.courseX.common.code.SuccessCode;
+
+import org.springframework.http.HttpStatus;
+
+public enum LogSuccess implements SuccessCode {
+  GET_LOG_LIST(HttpStatus.OK, "로그 조회에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  LogSuccess(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return httpStatus;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import com.acc.courseX.common.response.ResponseUtil;
 import com.acc.courseX.log.dto.LogResponse;
+import com.acc.courseX.log.entity.LogAction;
 import com.acc.courseX.log.service.LogService;
 
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class LogController {
   @GetMapping
   public ResponseEntity<?> getLogs(
       @RequestParam(required = false) Long userId,
-      @RequestParam(required = false) String actionType,
+      @RequestParam(required = false) LogAction actionType,
       @RequestParam(required = false) String targetTable,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate startDate,
@@ -39,8 +40,10 @@ public class LogController {
         startDate != null ? LocalDateTime.of(startDate, LocalTime.MIN) : null;
     LocalDateTime endDateTime = endDate != null ? LocalDateTime.of(endDate, LocalTime.MAX) : null;
 
+    String actionTypeName = (actionType != null) ? actionType.getActionName() : null;
+
     List<LogResponse> response =
-        logService.getLogs(userId, actionType, targetTable, startDateTime, endDateTime);
+        logService.getLogs(userId, actionTypeName, targetTable, startDateTime, endDateTime);
     return ResponseUtil.success(GET_LOG_LIST, response);
   }
 }

--- a/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/controller/LogController.java
@@ -1,0 +1,46 @@
+package com.acc.courseX.log.controller;
+
+import static com.acc.courseX.log.code.LogSuccess.GET_LOG_LIST;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import com.acc.courseX.common.response.ResponseUtil;
+import com.acc.courseX.log.dto.LogResponse;
+import com.acc.courseX.log.service.LogService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/logs")
+@RequiredArgsConstructor
+public class LogController {
+  private final LogService logService;
+
+  @GetMapping
+  public ResponseEntity<?> getLogs(
+      @RequestParam(required = false) Long userId,
+      @RequestParam(required = false) String actionType,
+      @RequestParam(required = false) String targetTable,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate) {
+
+    LocalDateTime startDateTime =
+        startDate != null ? LocalDateTime.of(startDate, LocalTime.MIN) : null;
+    LocalDateTime endDateTime = endDate != null ? LocalDateTime.of(endDate, LocalTime.MAX) : null;
+
+    List<LogResponse> response =
+        logService.getLogs(userId, actionType, targetTable, startDateTime, endDateTime);
+    return ResponseUtil.success(GET_LOG_LIST, response);
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/dto/LogResponse.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/dto/LogResponse.java
@@ -1,0 +1,41 @@
+package com.acc.courseX.log.dto;
+
+import java.time.LocalDateTime;
+
+import com.acc.courseX.log.entity.Log;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LogResponse {
+  private Long id;
+  private Long userId;
+  private String userName;
+  private String actionType;
+  private String targetTable;
+  private Long targetId;
+  private String metadata;
+  private String ipAddress;
+  private String userAgent;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime createdAt;
+
+  public static LogResponse from(Log log) {
+    return LogResponse.builder()
+        .id(log.getId())
+        .userId(log.getUser() != null ? log.getUser().getId() : null)
+        .userName(log.getUser() != null ? log.getUser().getName() : null)
+        .actionType(log.getActionType())
+        .targetTable(log.getTargetTable())
+        .targetId(log.getTargetId())
+        .metadata(log.getMetadata())
+        .ipAddress(log.getIpAddress())
+        .userAgent(log.getUserAgent())
+        .createdAt(log.getCreatedAt())
+        .build();
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/entity/Log.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/entity/Log.java
@@ -1,0 +1,79 @@
+package com.acc.courseX.log.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import com.acc.courseX.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "logs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Log {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(nullable = false)
+  private String actionType;
+
+  @Column(nullable = false)
+  private String targetTable;
+
+  private Long targetId;
+
+  @Column(columnDefinition = "JSON")
+  private String metadata;
+
+  private String ipAddress;
+
+  private String userAgent;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public Log(
+      User user,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      String ipAddress,
+      String userAgent) {
+    this.user = user;
+    this.actionType = actionType;
+    this.targetTable = targetTable;
+    this.targetId = targetId;
+    this.metadata = metadata;
+    this.ipAddress = ipAddress;
+    this.userAgent = userAgent;
+    this.createdAt = LocalDateTime.now(); // 이 부분에서 현재 시간으로 초기화
+  }
+
+  @PrePersist
+  public void prePersist() {
+    if (this.createdAt == null) {
+      this.createdAt = LocalDateTime.now();
+    }
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/entity/LogAction.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/entity/LogAction.java
@@ -1,0 +1,16 @@
+package com.acc.courseX.log.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LogAction {
+  VIEW_COURSE("view_course"),
+  ENROLL_COURSE("enroll_course"),
+  DROP_COURSE("drop_course"),
+  ENROLL_COURSE_FAILURE("enroll_course_failure"),
+  DROP_COURSE_FAILURE("drop_course_failure");
+
+  private final String actionName;
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/repository/LogRepository.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/repository/LogRepository.java
@@ -1,0 +1,36 @@
+package com.acc.courseX.log.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.acc.courseX.log.entity.Log;
+import com.acc.courseX.user.entity.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LogRepository extends JpaRepository<Log, Long> {
+  List<Log> findByUser(User user);
+
+  List<Log> findByActionType(String actionType);
+
+  List<Log> findByTargetTable(String targetTable);
+
+  List<Log> findByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+  @Query(
+      "SELECT l FROM Log l WHERE "
+          + "(:userId IS NULL OR l.user.id = :userId) AND "
+          + "(:actionType IS NULL OR l.actionType = :actionType) AND "
+          + "(:targetTable IS NULL OR l.targetTable = :targetTable) AND "
+          + "(:startDate IS NULL OR l.createdAt >= :startDate) AND "
+          + "(:endDate IS NULL OR l.createdAt <= :endDate) "
+          + "ORDER BY l.createdAt DESC")
+  List<Log> findWithFilters(
+      @Param("userId") Long userId,
+      @Param("actionType") String actionType,
+      @Param("targetTable") String targetTable,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogService.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogService.java
@@ -1,0 +1,25 @@
+package com.acc.courseX.log.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.dto.LogResponse;
+
+public interface LogService {
+  void createLog(
+      Long userId,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      HttpServletRequest request);
+
+  List<LogResponse> getLogs(
+      Long userId,
+      String actionType,
+      String targetTable,
+      LocalDateTime startDate,
+      LocalDateTime endDate);
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
@@ -13,6 +13,7 @@ import com.acc.courseX.user.entity.User;
 import com.acc.courseX.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class LogServiceImpl implements LogService {
   private final LogRepository logRepository;
   private final UserRepository userRepository;
 
+  @Async("logTaskExecutor")
   @Override
   @Transactional
   public void createLog(

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
@@ -1,0 +1,82 @@
+package com.acc.courseX.log.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.acc.courseX.log.dto.LogResponse;
+import com.acc.courseX.log.entity.Log;
+import com.acc.courseX.log.repository.LogRepository;
+import com.acc.courseX.user.entity.User;
+import com.acc.courseX.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LogServiceImpl implements LogService {
+  private final LogRepository logRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public void createLog(
+      Long userId,
+      String actionType,
+      String targetTable,
+      Long targetId,
+      String metadata,
+      HttpServletRequest request) {
+    User user = null;
+    if (userId != null) {
+      user = userRepository.findById(userId).orElse(null);
+    }
+
+    String ipAddress = getClientIp(request);
+    String userAgent = request.getHeader("User-Agent");
+
+    Log log =
+        Log.builder()
+            .user(user)
+            .actionType(actionType)
+            .targetTable(targetTable)
+            .targetId(targetId)
+            .metadata(metadata)
+            .ipAddress(ipAddress)
+            .userAgent(userAgent)
+            .build();
+
+    logRepository.save(log);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<LogResponse> getLogs(
+      Long userId,
+      String actionType,
+      String targetTable,
+      LocalDateTime startDate,
+      LocalDateTime endDate) {
+    List<Log> logs =
+        logRepository.findWithFilters(userId, actionType, targetTable, startDate, endDate);
+    return logs.stream().map(LogResponse::from).collect(Collectors.toList());
+  }
+
+  private String getClientIp(HttpServletRequest request) {
+    String ipAddress = request.getHeader("X-Forwarded-For");
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getRemoteAddr();
+    }
+    return ipAddress;
+  }
+}

--- a/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
+++ b/courseX-backend/src/main/java/com/acc/courseX/log/service/LogServiceImpl.java
@@ -19,6 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class LogServiceImpl implements LogService {
+  private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
+  private static final String HEADER_PROXY_CLIENT_IP = "Proxy-Client-IP";
+  private static final String HEADER_WL_PROXY_CLIENT_IP = "WL-Proxy-Client-IP";
+  private static final String UNKNOWN = "unknown";
+
   private final LogRepository logRepository;
   private final UserRepository userRepository;
 
@@ -67,14 +72,14 @@ public class LogServiceImpl implements LogService {
   }
 
   private String getClientIp(HttpServletRequest request) {
-    String ipAddress = request.getHeader("X-Forwarded-For");
-    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
-      ipAddress = request.getHeader("Proxy-Client-IP");
+    String ipAddress = request.getHeader(HEADER_X_FORWARDED_FOR);
+    if (ipAddress == null || ipAddress.isEmpty() || UNKNOWN.equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader(HEADER_PROXY_CLIENT_IP);
     }
-    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
-      ipAddress = request.getHeader("WL-Proxy-Client-IP");
+    if (ipAddress == null || ipAddress.isEmpty() || UNKNOWN.equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader(HEADER_WL_PROXY_CLIENT_IP);
     }
-    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+    if (ipAddress == null || ipAddress.isEmpty() || UNKNOWN.equalsIgnoreCase(ipAddress)) {
       ipAddress = request.getRemoteAddr();
     }
     return ipAddress;


### PR DESCRIPTION
# 📄 Work Description
- 사용자 로그 조회 API를 구현했습니다.
- 조회 가능한 요소는 다음과 같습니다.
  - 사용자 ID별 필터링: `userId=1`
  - 액션 타입별 필터링: `actionType=enroll_course`, `drop_course`, `view_course`, `view_enrollment`
  - 날짜 범위 필터링: `startDate=2025-04-01&endDate=2025-04-30`
  - 타겟 테이블별 필터링: `targetTable=courses`, `enrollments`


# ⚙️ ISSUE
- closed #7 


# 📷 Screenshot
![image](https://github.com/user-attachments/assets/8f13264f-026b-4272-a108-aebe1146bb00)



# 💬 To Reviewers
로그 조회 요소로 추가할 것이 있다면 말씀해주세요.


# 🔗 Reference
