### PR TITLE
[Feat/#42] 모니터링 환경 셋팅

### DIFF
--- a/courseX-backend/build.gradle.kts
+++ b/courseX-backend/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("io.micrometer:micrometer-registry-prometheus")
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/courseX-backend/build.gradle.kts
+++ b/courseX-backend/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
+	implementation("io.micrometer:micrometer-registry-prometheus")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/courseX-backend/src/main/resources/application-dev.yaml
+++ b/courseX-backend/src/main/resources/application-dev.yaml
@@ -4,6 +4,7 @@ spring:
       on-profile: dev
     import:
       - classpath:jpa.yaml
+      - classpath:monitoring.yaml
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/courseX-backend/src/main/resources/application-local.yaml
+++ b/courseX-backend/src/main/resources/application-local.yaml
@@ -4,6 +4,7 @@ spring:
       on-profile: local
     import:
       - classpath:jpa.yaml
+      - classpath:monitoring.yaml
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/courseX-backend/src/main/resources/monitoring.yaml
+++ b/courseX-backend/src/main/resources/monitoring.yaml
@@ -1,0 +1,12 @@
+management:
+  health:
+    redis:
+      enabled: false
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+      base-path: ${ACTUATOR_PATH}


### PR DESCRIPTION
# 📄 Work Description
<!-- 작업에 대한 설명을 작성해주세요 -->
- prometheus, actuator 의존성을 추가하고 yaml에 actuator 관련 엔드포인트를 어떤 것을 노출시킬지 명시해주었습니다
- 또한 actuator의 base_path를 변경하여 외부 사용자는 actuator를 통한 값 조회를 할 수 없도록 막아보았습니다
  - header로 x-api-key 등을 설정하여 보안을 높이는 방법도 있습니다
  - 그러나 현재 spring security를 사용하지 않는다는 점
  - 또한 해당 프로젝트를 배포할 것이 아닌 부하 테스트 이후 모두 서버를 내릴 것을 고려하였고
  - 최대한 변경 사항을 줄이고자 base_path만 수정해보았습니다! 

# ⚙️ ISSUE
- closed #42


# 📷 Screenshot
<!-- ex) 스웨거, 포스트맨 등의 기록을 첨부해주세요 -->
- actuator 활성화 확인
![image](https://github.com/user-attachments/assets/270aceed-56ff-49fd-a5fe-f1f9cf8813f9)


# 💬 To Reviewers
<!-- 리뷰어에게 하고싶은 말 -->
- 해당 PR 머지되고 CD 플로우까지 수정되면 alloy 설정도 해두겠습니다!
- 모니터링 서버(ec2)에 prometheus, grafana 설정은 모두 해두었습니다!

# 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)를 첨부해주세요 -->